### PR TITLE
CLOUD-41985: remove 'cbd init' from create-db-tgz.sh

### DIFF
--- a/create-db-tgz.sh
+++ b/create-db-tgz.sh
@@ -16,8 +16,6 @@ start_db(){
 
   echo 'export PUBLIC_IP=1.1.1.1'>Profile
   echo "export DOCKER_TAG_${APP_NAME}=${ver}" >> Profile
-  cbd init
-  #cbd pull
 
   $(cbd env export | grep POSTGRES)
 


### PR DESCRIPTION
@akanto or @lalyos pls review

depends on https://github.com/sequenceiq/cloudbreak-deployer/pull/98
